### PR TITLE
【スマホ対応】ResponsiveSelectをコンポーネント化し、isMobileをutil化・スマホで純正<select>を利用

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,7 @@ import { useRatingQueryParam } from "@/hooks/useRatingQueryParam";
 import { useSortQueryParam } from "@/hooks/useSortQueryParam";
 import Link from "next/link";
 import type { Product, Category } from "@/types/product";
+import { ResponsiveSelect } from "@/components/ResponsiveSelect";
 
 export default function ProductComparisonSite() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -148,34 +149,18 @@ export default function ProductComparisonSite() {
         <div>
           <h3 className="font-semibold mb-3">評価</h3>
           <div className="p-2">
-            <Select
+            <ResponsiveSelect
               value={minRating.toString()}
-              onValueChange={(value) => setMinRating(Number(value))}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <Link href="/?rating=0" passHref legacyBehavior>
-                  <SelectItem value="0">すべて</SelectItem>
-                </Link>
-                <Link href="/?rating=1" passHref legacyBehavior>
-                  <SelectItem value="1">★1以上</SelectItem>
-                </Link>
-                <Link href="/?rating=2" passHref legacyBehavior>
-                  <SelectItem value="2">★2以上</SelectItem>
-                </Link>
-                <Link href="/?rating=3" passHref legacyBehavior>
-                  <SelectItem value="3">★3以上</SelectItem>
-                </Link>
-                <Link href="/?rating=4" passHref legacyBehavior>
-                  <SelectItem value="4">★4以上</SelectItem>
-                </Link>
-                <Link href="/?rating=5" passHref legacyBehavior>
-                  <SelectItem value="5">★5のみ</SelectItem>
-                </Link>
-              </SelectContent>
-            </Select>
+              onChange={(v) => setMinRating(Number(v))}
+              options={[
+                { value: "0", label: "すべて" },
+                { value: "1", label: "★1以上" },
+                { value: "2", label: "★2以上" },
+                { value: "3", label: "★3以上" },
+                { value: "4", label: "★4以上" },
+                { value: "5", label: "★5のみ" },
+              ]}
+            />
           </div>
         </div>
       </div>
@@ -282,25 +267,16 @@ export default function ProductComparisonSite() {
                 </p>
               </div>
 
-              <Select value={sort} onValueChange={setSort}>
-                <SelectTrigger className="w-full sm:w-48">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <Link href="/?sort=rating-desc" passHref legacyBehavior>
-                    <SelectItem value="rating-desc">評価の高い順</SelectItem>
-                  </Link>
-                  <Link href="/?sort=rating-asc" passHref legacyBehavior>
-                    <SelectItem value="rating-asc">評価の低い順</SelectItem>
-                  </Link>
-                  <Link href="/?sort=price-asc" passHref legacyBehavior>
-                    <SelectItem value="price-asc">価格の安い順</SelectItem>
-                  </Link>
-                  <Link href="/?sort=price-desc" passHref legacyBehavior>
-                    <SelectItem value="price-desc">価格の高い順</SelectItem>
-                  </Link>
-                </SelectContent>
-              </Select>
+              <ResponsiveSelect
+                value={sort}
+                onChange={setSort}
+                options={[
+                  { value: "rating-desc", label: "評価の高い順" },
+                  { value: "rating-asc", label: "評価の低い順" },
+                  { value: "price-asc", label: "価格の安い順" },
+                  { value: "price-desc", label: "価格の高い順" },
+                ]}
+              />
             </div>
 
             {/* 商品グリッド */}

--- a/components/ResponsiveSelect.tsx
+++ b/components/ResponsiveSelect.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useEffect, useState } from "react";
+import { isMobile } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type Option = { value: string; label: string };
+
+export function ResponsiveSelect({
+  value,
+  onChange,
+  options,
+  className = "",
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Option[];
+  className?: string;
+}) {
+  const [mobile, setMobile] = useState(false);
+  useEffect(() => {
+    setMobile(isMobile());
+  }, []);
+
+  if (mobile) {
+    return (
+      <div className={`relative w-full sm:w-48 ${className}`}>
+        <select
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full border border-input rounded-md bg-white px-3 py-2 text-sm shadow-xs focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none transition h-9"
+        >
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className={`w-full sm:w-48 ${className}`}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,11 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+export function isMobile(): boolean {
+  if (typeof window === "undefined") return false;
+  return /iPhone|Android.+Mobile|iPad|iPod/.test(navigator.userAgent);
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## 概要

Radix UIのSelectコンポーネントをNext.js + shadcn/ui環境で利用している際、  
PCでは正常に動作するものの、スマホ（iOS/Android）では選択肢をタップしてもドロップダウンが自動で閉じない問題が発生していました。

## 主な対応内容

- スマホ（iOS/Android）環境では純正の`<select>`タグを利用するように変更
- PC環境では従来通りRadix UI Selectを利用
- `<select>`にもカスタムSelectに近い見た目のスタイルを適用し、UIの統一感を向上
- isMobile判定を`lib/utils.ts`にユーティリティ関数として切り出し
- ResponsiveSelectを`components/ResponsiveSelect.tsx`に分離し、再利用可能なコンポーネント化
- `app/page.tsx`ではそれぞれimportして利用

## 再現手順

1. スマホ（iOS/Android）でページを開く
2. ソートや評価のセレクトボックスをタップしてドロップダウンを開く
3. 任意の選択肢をタップ
4. ドロップダウンが自動で閉じ、選択状態が反映される

## 備考

- PCでは従来通りカスタムUIのままです
- スマホではOS標準のUIとなるため、アクセシビリティや操作性も向上します
- isMobile/ResponsiveSelectの分離により、再利用性・保守性・可読性が大きく向上しています

## 関連ISSUE

https://github.com/ryosuketter/my-item/issues/1